### PR TITLE
Get Help Database Integration

### DIFF
--- a/src/js/controllers/controllers.js
+++ b/src/js/controllers/controllers.js
@@ -77,34 +77,49 @@ app.controller('AccountCtrl', function($scope) {
   };
 })
 
-app.controller('GetHelpCtrl', function($scope, GetHelp, $ionicPopup, sqlService) {
+app.controller('GetHelpCtrl', function($scope, GetHelp, $ionicPopup, sqlService, $ionicLoading) {
   $scope.help = "no help yet yo";
   $scope.retrieveGoodStrategies = function () {
+    $ionicLoading.show({});
     console.log('called good');
     $scope.specificStrats = null;
-    $scope.goodStrats = GetHelp.pastStrategies();
+    $scope.goodStrats = []
+    sqlService.executeQuery('SELECT * FROM feedback').then(function(result){
+			for (var i = 0; i < result.rows.length; i++) {
+				console.log("Query result", result.rows.item(i));
+				if (result.rows.item(i).response === 1) {
+					$scope.goodStrats.push(result.rows.item(i));
+				}
+        $ionicLoading.hide();
+			}
+    console.log($scope.goodStrats);
+    }),
+    (err) => console.log("Query error", err)
   };
   $scope.retrieveSpecificStrategies = function () {
     console.log('called specific');
     $scope.goodStrats = null;
     $scope.specificStrats = GetHelp.specificStrategies();
+    console.log(JSON.stringify($scope.specificStrats));
   }
   $scope.rate = function (strategy) {
    var confirmPopup = $ionicPopup.confirm({
      title: 'Does this stragegy work for you?',
-     template: 'Your feedback helps us help you!'
+     template: 'Your feedback helps us help you!',
+     cancelText: 'No',
+     OkText: 'Yes'
    });
 
    confirmPopup.then(function(res) {
      if(res) {
        console.log('They like the strategy');
-       sqlService.executeQuery('UPDATE feedback SET response = 1 WHERE copingStrategy = ?', [strategy.name]).then(
+       sqlService.executeQuery('UPDATE feedback SET response = 1 WHERE name = ?', [strategy.name]).then(
          (result) => console.log("Query result", result.rows.item(0)),
          (err) => console.log("Query error", err)
        );
      } else {
        console.log('They dont like the strategy');
-       sqlService.executeQuery('UPDATE feedback SET response = 0 WHERE copingStrategy = ?', [strategy.name]).then(
+       sqlService.executeQuery('UPDATE feedback SET response = 0 WHERE name = ?', [strategy.name]).then(
          (result) => console.log("Query result", result.rows.item(0)),
          (err) => console.log("Query error", err)
        );

--- a/src/js/controllers/controllers.js
+++ b/src/js/controllers/controllers.js
@@ -77,7 +77,7 @@ app.controller('AccountCtrl', function($scope) {
   };
 })
 
-app.controller('GetHelpCtrl', function($scope, GetHelp) {
+app.controller('GetHelpCtrl', function($scope, GetHelp, $ionicPopup) {
   $scope.help = "no help yet yo";
   $scope.retrieveGoodStrategies = function () {
     console.log('called good');
@@ -89,6 +89,28 @@ app.controller('GetHelpCtrl', function($scope, GetHelp) {
     $scope.goodStrats = null;
     $scope.specificStrats = GetHelp.specificStrategies();
   }
+  $scope.rate = function (strategy) {
+   var confirmPopup = $ionicPopup.confirm({
+     title: 'Does this stragegy work for you?',
+     template: 'Your feedback helps us help you!'
+   });
+
+   confirmPopup.then(function(res) {
+     if(res) {
+       console.log('They like the strategy');
+       sqlService.executeQuery('UPDATE feedback SET response = 1 WHERE copingStrategy = ?', [strategy.name]).then(
+         (result) => console.log("Query result", result.rows.item(0)),
+         (err) => console.log("Query error", err)
+       );
+     } else {
+       console.log('They dont like the strategy');
+       sqlService.executeQuery('UPDATE feedback SET response = 0 WHERE copingStrategy = ?', [strategy.name]).then(
+         (result) => console.log("Query result", result.rows.item(0)),
+         (err) => console.log("Query error", err)
+       );
+     }
+   });
+ };
 });
 
 app.controller('LineCtrl', function($scope) {

--- a/src/js/controllers/controllers.js
+++ b/src/js/controllers/controllers.js
@@ -77,7 +77,7 @@ app.controller('AccountCtrl', function($scope) {
   };
 })
 
-app.controller('GetHelpCtrl', function($scope, GetHelp, $ionicPopup) {
+app.controller('GetHelpCtrl', function($scope, GetHelp, $ionicPopup, sqlService) {
   $scope.help = "no help yet yo";
   $scope.retrieveGoodStrategies = function () {
     console.log('called good');

--- a/src/js/services/GetHelpService.js
+++ b/src/js/services/GetHelpService.js
@@ -1,4 +1,4 @@
-app.factory('GetHelp', function() {
+app.factory('GetHelp', function(sqlService) {
 
 	/* Proposed IDs associated with moods
 	Mood        ID
@@ -20,23 +20,29 @@ app.factory('GetHelp', function() {
 	}
 	*/
 
-	//Get latest mood log
-	//Will be retrieved from database once it is setup
-	// For now, make it a placeholder.
 	var latestMoodLog = {
-		mood: 0
+		mood: 5
 	};
+//Get all the mood logs?
+	sqlService.executeQuery('SELECT * FROM mood_logs').then(function(result){
+		console.log("Query result", result.rows.item(1))
+		latestMoodLog.mood = result.rows.item(1).id;
+	}),
+		(err) => console.log("Query error", err)
+
+
+
 
 	//Coping strategies for anger
 	var angerStrats = [
-		"Go to the gym",
-		"Go for a walk"
+		{name:"Go to the gym", id: 0},
+		{name:"Go for a walk", id: 1}
 	];
 
 	//Coping strategies for disgust
 	var disgustStrats = [
-		"Speak with a trusted family member about your day",
-		"Take a bath"
+		{name: "Speak with a trusted family member about your day", id: 0},
+		{name:"Take a bath", id: 1}
 	];
 
 	//Coping strategies for fear

--- a/src/js/services/GetHelpService.js
+++ b/src/js/services/GetHelpService.js
@@ -30,9 +30,6 @@ app.factory('GetHelp', function(sqlService) {
 	}),
 		(err) => console.log("Query error", err)
 
-
-
-
 	//Coping strategies for anger
 	var angerStrats = [
 		{name:"Go to the gym", id: 0},
@@ -111,8 +108,18 @@ app.factory('GetHelp', function(sqlService) {
 	}
 
 	//Returns an array of coping strategies that have worked in the past
-	function getGoodStrategies() {
-		var filtered = allFeedback;
+	function getGoodStrategies(cb) {
+		var strats = []
+		sqlService.executeQuery('SELECT * FROM feedback').then(function(result){
+			for (var i = 0; i < result.rows.length; i++) {
+				console.log("Query result", result.rows.item(i));
+				if (result.rows.item(i).response === 1) {
+					cb(result.rows.item(i));
+				}
+			}
+			return strats;
+		}),
+			(err) => console.log("Query error", err)
 		/*  uncomment when we know how to get
 		 * whether or not a strategy is "good" or not.
 		 * FOr now, this funciton returns ALL coping strats.
@@ -123,7 +130,6 @@ app.factory('GetHelp', function(sqlService) {
 			}
 		})
 		*/
-		return filtered;
 	}
 
 	//Return general coping strategies, specific coping strategies, and coping strategies that have worked in the past

--- a/src/js/services/SQLService/sqlservice.js
+++ b/src/js/services/SQLService/sqlservice.js
@@ -8,7 +8,10 @@ app.factory('sqlService', function($cordovaSQLite) {
 	popQrys.mood_logs = [
 		'DROP TABLE IF EXISTS mood_logs',
 		'CREATE TABLE mood_logs(id INTEGER PRIMARY KEY NOT NULL,\
-		mood TEXT NOT NULL, intensity INTEGER NOT NULL, trigger TEXT NOT NULL, behavior TEXT NOT NULL, belief TEXT NOT NULL)'
+		mood TEXT NOT NULL, intensity INTEGER NOT NULL, trigger TEXT NOT NULL, behavior TEXT NOT NULL, belief TEXT NOT NULL)',
+		'INSERT INTO mood_logs (id, mood, intensity, trigger, behavior, belief) VALUES\
+		(0, "angry", "10", "gordon anderson", "bought wrench", "wrenches fix stuff"),\
+		(1, "disgust", "6", "gordon anderson", "bought wrench", "wrenches fix stuff")'
 	];
 
 	popQrys.pattern_features = [
@@ -30,6 +33,10 @@ app.factory('sqlService', function($cordovaSQLite) {
 		("Watch Spongebob", 1),\
 		("Go to the gym", 0),\
 		("Call a family member or friend", 1),\
+		("Take a bath", 0),\
+		("Go to the gym", 0),\
+		("Go for a walk", 0),\
+		("Speak with a trusted family member about your day", 0),\
 		("Take a bath", 0),\
 		("Keep being happy!", 0),\
 		("Watch television", 1)'
@@ -108,11 +115,11 @@ app.factory('sqlService', function($cordovaSQLite) {
 	** Args: qry ( an SQL query, String )
 	** Returns: Promise sucess(resultSet), error(error)
 	*/
-	service.executeQuery = (qry) => {
+	service.executeQuery = (qry, vals) => {
 		return new Promise((resolve, reject) => {
 			if(db === null) reject("DB connection not initiated. Call init() before running queries.");
-
-			db.executeSql(qry, [], (resultSet) => {
+			if (vals == null) vals = []
+			db.executeSql(qry, vals, (resultSet) => {
 				resolve(resultSet);
 			}, (error) => reject(error));
 		});

--- a/src/js/services/SQLService/sqlservice.js
+++ b/src/js/services/SQLService/sqlservice.js
@@ -28,8 +28,8 @@ app.factory('sqlService', function($cordovaSQLite) {
 	];
 	popQrys.feedback = [
 		'DROP TABLE IF EXISTS feedback',
-		'CREATE TABLE feedback( copingStrategy TEXT PRIMARY KEY, response INTEGER NOT NULL )',
-		'INSERT INTO feedback (copingStrategy, response) VALUES\
+		'CREATE TABLE feedback( name TEXT PRIMARY KEY, response INTEGER NOT NULL )',
+		'INSERT INTO feedback (name, response) VALUES\
 		("Watch Spongebob", 1),\
 		("Go to the gym", 0),\
 		("Call a family member or friend", 1),\

--- a/src/js/services/SQLService/sqlservice.js
+++ b/src/js/services/SQLService/sqlservice.js
@@ -34,10 +34,8 @@ app.factory('sqlService', function($cordovaSQLite) {
 		("Go to the gym", 0),\
 		("Call a family member or friend", 1),\
 		("Take a bath", 0),\
-		("Go to the gym", 0),\
 		("Go for a walk", 0),\
 		("Speak with a trusted family member about your day", 0),\
-		("Take a bath", 0),\
 		("Keep being happy!", 0),\
 		("Watch television", 1)'
 	];

--- a/www/templates/tab-get-help.html
+++ b/www/templates/tab-get-help.html
@@ -11,9 +11,9 @@
         <ion-icon class="icon ion-ios-help"></ion-icon>
         {{strat}}
       </ion-item>
-      <ion-item class="item item-icon-left" ng-repeat="strat in specificStrats">
+      <ion-item class="item item-icon-left" ng-repeat="strat in specificStrats" ng-click="rate(strat)">
         <ion-icon class="icon ion-ios-help"></ion-icon>
-        {{strat}}
+        {{strat.name}}
       </ion-item>
     </ion-list>
 

--- a/www/templates/tab-get-help.html
+++ b/www/templates/tab-get-help.html
@@ -7,9 +7,9 @@
       Get Good Strategies
     </button>
     <ion-list class="list card">
-      <ion-item class="item item-icon-left" ng-repeat="strat in goodStrats">
+      <ion-item class="item item-icon-left" ng-repeat="strat in goodStrats" ng-click="rate(strat)">
         <ion-icon class="icon ion-ios-help"></ion-icon>
-        {{strat}}
+        {{strat.name}}
       </ion-item>
       <ion-item class="item item-icon-left" ng-repeat="strat in specificStrats" ng-click="rate(strat)">
         <ion-icon class="icon ion-ios-help"></ion-icon>


### PR DESCRIPTION
This PR adds full database support (r/w for feedback/coping strategies) to the Get Help page in the app.  Makes changes to GetHelp factory not necessarily in line with @raymondtang310's original plans for it, but they needed to be done in order to get it working.

As of this PR, Get Help is essentially feature-complete.  The one thing remaining is that it always grabs the second mood currently logged in the `mood_log` table in the database; once Log Mood is finished, that can be changed.
